### PR TITLE
docs: プロジェクト概要とスタックを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,23 @@
 # CLAUDE.md - Guidelines for Coedo-Ooedo 2025 Simulator
 
+## Project Overview
+小江戸大江戸マラソン2025のレース進行をシミュレートする可視化ツールです。ランナー位置を地図上にリアルタイムで表示し、レース進行を時系列で確認できます。
+
+### 主な機能
+- 複数コース対応（200km/230km/260km/90km/115km）
+- ランナー位置のアニメーション表示
+- タイムラインによるレース進行確認
+- カテゴリ別フィルタリング
+- ランナー検索・フォーカス機能
+
+### 技術スタック
+- React + TypeScript
+- deck.gl + MapLibre GL
+- Zustand（状態管理）
+- Tailwind CSS
+- Vite（ビルドツール）
+- Vitest（テスト）
+
 ## Commands
 - `pnpm dev` - Start development server
 - `pnpm build` - Build for production

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# CLAUDE.md - Guidelines for Coedo-Ooedo 2025 Simulator
+
+## Commands
+- `pnpm dev` - Start development server
+- `pnpm build` - Build for production
+- `pnpm lint` - Run ESLint
+- `pnpm test` - Run all tests
+- `pnpm test src/utils/__tests__/timeUtils.test.ts` - Run a specific test file
+- `pnpm test -t "test name pattern"` - Run tests matching a specific pattern
+
+## Code Style Guidelines
+- **TypeScript**: Use strict mode with proper type annotations
+- **Imports**: Group imports by: external libraries, then internal modules
+- **Components**: React functional components with explicit return types
+- **Error Handling**: Try/catch blocks with error logging and re-throwing
+- **State Management**: Use Zustand for global state
+- **Naming**: camelCase for variables/functions, PascalCase for components/types
+- **Comments**: JSDoc style for functions and complex logic
+- **File Structure**: Group related functionality in dedicated folders
+- **React Hooks**: Follow rules of hooks, use custom hooks for shared logic
+- **Testing**: Use Vitest with describe/it pattern, mock data as needed

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ GitHub Pages へ自動デプロイしています。デプロイ設定は以下�
 - `src/utils/`: ユーティリティ関数
 - `src/data/`: シミュレーションデータ
 - `src/types/`: TypeScript 型定義
+- `CLAUDE.md`: 開発ガイドラインとClaude AIアシスタント用の設定ファイル
 
 ## 主要コンポーネント
 


### PR DESCRIPTION
## Summary
- CLAUDE.mdにプロジェクト概要、主な機能、技術スタック情報を追加
- 新規開発者がプロジェクトを素早く理解できるようにドキュメントを改善

## Test plan
- ドキュメントの変更のみのため、特別なテストは不要

🤖 Generated with [Claude Code](https://claude.ai/code)