### PR TITLE
Fix smartphone drawer menu zoom issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>小江戸大江戸2025シミュレーター</title>
 
     <meta


### PR DESCRIPTION
## 問題点\nスマートフォン環境で左上のボタンを押すとDrawerメニューが表示された後に画面全体が拡大表示になり、ボタン類が画面からはみ出てしまう問題を修正しました。\n\n## 修正内容\nviewport meta tagにとを追加し、スマートフォンでの自動ズームを防止しました。\n\n\n\nこの変更により、Drawerメニューを開いた際に画面が拡大されず、すべてのボタンが正しく表示されるようになります。