### PR TITLE
Fix: スマートフォン環境でDrawerメニュー表示時の画面拡大問題を修正 (#113)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>小江戸大江戸2025シミュレーター</title>
 
     <meta


### PR DESCRIPTION
## 修正内容\n\n- スマートフォン環境で左上のボタン（Drawerメニュー）を押したときに画面全体が拡大表示される問題を修正\n- viewportメタタグにとを追加して、ユーザーによるズームを無効化\n\n## 関連Issue\n\nCloses #113