### PR TITLE
スマートフォン環境でDrawerメニュー表示時に画面が拡大される問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>小江戸大江戸2025シミュレーター</title>
 
     <meta

--- a/src/components/DrawerLeftMenu.tsx
+++ b/src/components/DrawerLeftMenu.tsx
@@ -5,7 +5,11 @@ import { DrawerMenu } from './DrawerMenu';
 export const DrawerLeftMenu = () => {
   const { isLeftDrawerMenuOpen, setIsLeftDrawerMenuOpen } = useAppStore();
 
-  const onClose = () => {
+  const onClose = (e?: React.MouseEvent | React.TouchEvent) => {
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     setIsLeftDrawerMenuOpen(false);
   };
 

--- a/src/components/DrawerMenu.tsx
+++ b/src/components/DrawerMenu.tsx
@@ -5,6 +5,13 @@ import { useAnimationStore } from '../store';
 import { FocusNumberInput } from './FocusNumberInput';
 
 export const DrawerMenu = () => {
+  // タッチイベントの拡大を防止するための関数
+  const preventZoom = (e: React.TouchEvent) => {
+    if (e.touches.length > 1) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
   const {
     isTextLayerVisible,
     toggleTextLayerVisibility,
@@ -17,7 +24,10 @@ export const DrawerMenu = () => {
   const { animationSpeed, setAnimationSpeed } = useAnimationStore();
 
   return (
-    <>
+    <div 
+      onTouchStart={preventZoom}
+      onTouchMove={preventZoom}
+    >
       <Divider orientation="center">検索</Divider>
 
       <FocusNumberInput />
@@ -92,6 +102,6 @@ export const DrawerMenu = () => {
           />
         </div>
       </div>
-    </>
+    </div>
   );
 };

--- a/src/components/DrawerOpenLeftButton.tsx
+++ b/src/components/DrawerOpenLeftButton.tsx
@@ -4,11 +4,19 @@ import { MenuOutlined } from '@ant-design/icons';
 export const DrawerOpenLeftButton = () => {
   const { setIsLeftDrawerMenuOpen } = useAppStore();
 
+  const handleClick = (e: React.MouseEvent | React.TouchEvent) => {
+    // クリックイベントの伝播を止めてズームを防止
+    e.preventDefault();
+    e.stopPropagation();
+    setIsLeftDrawerMenuOpen(true);
+  };
+
   return (
     <div className="fixed top-2 left-2 z-10">
       <MenuOutlined
         style={{ fontSize: '18px', color: '#fff' }}
-        onClick={() => setIsLeftDrawerMenuOpen(true)}
+        onClick={handleClick}
+        onTouchEnd={handleClick}
       />
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,14 @@
 @layer base {
   body {
     @apply bg-white dark:bg-gray-900;
+    touch-action: manipulation;
+    -webkit-text-size-adjust: 100%;
   }
+}
+
+/* モバイルデバイスでのダブルタップによるズームを防止 */
+* {
+  touch-action: manipulation;
 }
 
 /* 既存のCSSスタイル（あれば）をここに保持 */


### PR DESCRIPTION
## 概要
Issue #113 「スマートフォン環境で左上のボタンを押すと画面全体が拡大表示になってしまう」問題を修正しました。

## 修正内容
以下の変更を実施して問題を解決しました：

1. ビューポートのメタタグを更新し、ユーザーによるズームを防止
   - `maximum-scale=1.0` と `user-scalable=no` を追加

2. イベントハンドリングを改善
   - `DrawerOpenLeftButton` にイベント伝播を防止する処理を追加
   - `DrawerLeftMenu` の `onClose` 関数を修正し、イベント伝播を防止
   - `DrawerMenu` にタッチイベントハンドラーを追加し、マルチタッチジェスチャーを防止

3. グローバルCSSを改善
   - `touch-action: manipulation` を追加してタッチ操作の挙動を制御
   - `-webkit-text-size-adjust: 100%` を追加してテキストサイズの自動調整を防止

## テスト計画
- モバイル端末で左上のボタンをタップし、メニューが表示されても画面がズームしないことを確認
- メニュー内の各スライダーやボタンを操作しても画面がズームしないことを確認
- 通常の地図操作（ピンチズーム）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)